### PR TITLE
Draft PR for multi-communicator support

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -68,10 +68,14 @@ class HorovodBasics(object):
                 # Here we assume we are retrieving a list of MPI communicators
                 # TODO: assert that this is what we get
                 from mpi4py import MPI
+                if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
+                    MPI_Comm = ctypes.c_int
+                else:
+                    MPI_Comm = ctypes.c_void_p
+                    self.MPI_LIB_CTYPES.horovod_init_multi_comm.argtypes = [MPI_Comm, ctypes.c_int]
                 comms = [MPI_Comm.from_address(MPI._addressof(c)) for c in comm]
                 comm_size = len(comm)
-                self.MPI_LIB_CTYPES.horovod_init_multi_comm(*comms, ctypes.c_int(comm_size))
-                
+                self.MPI_LIB_CTYPES.horovod_init_multi_comm((ctypes.c_void_p * comm_size)(*comms), ctypes.c_int(comm_size))
 
     def shutdown(self):
         """A function that shuts Horovod down."""

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -116,7 +116,7 @@ class HorovodBasics(object):
         Returns:
           An integer scalar containing the number of Horovod processes.
         """
-        size = self.MPI_LIB_CTYPES.horovod_communicator_size(ctypes.int(communicator_id))
+        size = self.MPI_LIB_CTYPES.horovod_communicator_size(ctypes.c_int32(communicator_id))
         if size == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')
@@ -156,7 +156,7 @@ class HorovodBasics(object):
         Returns:
           An integer scalar with the Horovod rank of the calling process.
         """
-        rank = self.MPI_LIB_CTYPES.horovod_communicator_rank(ctypes.int(communicator_id))
+        rank = self.MPI_LIB_CTYPES.horovod_communicator_rank(ctypes.c_int32(communicator_id))
         if rank == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -60,7 +60,7 @@ class HorovodBasics(object):
             comm_obj = MPI_Comm.from_address(MPI._addressof(comm))
             self.MPI_LIB_CTYPES.horovod_init_comm(comm_obj)
         else:
-            if isinstance(comm[0], int):            
+            if (len(comm) ==0) or isinstance(comm[0], int):            
                 comm_size = len(comm)
                 self.MPI_LIB_CTYPES.horovod_init(
                     (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -110,13 +110,13 @@ class HorovodBasics(object):
         if not result:
             raise ValueError('Horovod has not been initialized; use hvd.init().')
 
-    def size(self):
+    def size(self, communicator_id=0):
         """A function that returns the number of Horovod processes.
 
         Returns:
           An integer scalar containing the number of Horovod processes.
         """
-        size = self.MPI_LIB_CTYPES.horovod_size()
+        size = self.MPI_LIB_CTYPES.horovod_size(ctypes.int(communicator_id))
         if size == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')
@@ -150,13 +150,13 @@ class HorovodBasics(object):
                 'Horovod has not been initialized; use hvd.init().')
         return cross_size
 
-    def rank(self):
+    def rank(self, communicator_id=0):
         """A function that returns the Horovod rank of the calling process.
 
         Returns:
           An integer scalar with the Horovod rank of the calling process.
         """
-        rank = self.MPI_LIB_CTYPES.horovod_rank()
+        rank = self.MPI_LIB_CTYPES.horovod_rank(ctypes.int(communicator_id))
         if rank == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -116,7 +116,7 @@ class HorovodBasics(object):
         Returns:
           An integer scalar containing the number of Horovod processes.
         """
-        size = self.MPI_LIB_CTYPES.horovod_size(ctypes.int(communicator_id))
+        size = self.MPI_LIB_CTYPES.horovod_communicator_size(ctypes.int(communicator_id))
         if size == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')
@@ -156,7 +156,7 @@ class HorovodBasics(object):
         Returns:
           An integer scalar with the Horovod rank of the calling process.
         """
-        rank = self.MPI_LIB_CTYPES.horovod_rank(ctypes.int(communicator_id))
+        rank = self.MPI_LIB_CTYPES.horovod_communicator_rank(ctypes.int(communicator_id))
         if rank == -1:
             raise ValueError(
                 'Horovod has not been initialized; use hvd.init().')

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -301,7 +301,7 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
           if (count == (size_ - state.joined_size) &&
               std::find(ready_to_reduce.begin(), ready_to_reduce.end(),
                         table_iter.first) == ready_to_reduce.end()) {
-            timeline_.NegotiateEnd(table_iter.first);
+            state.timeline.NegotiateEnd(table_iter.first);
             ready_to_reduce.push_back(table_iter.first);
           }
         }

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -301,7 +301,7 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
           if (count == (size_ - state.joined_size) &&
               std::find(ready_to_reduce.begin(), ready_to_reduce.end(),
                         table_iter.first) == ready_to_reduce.end()) {
-            state.timeline.NegotiateEnd(table_iter.first);
+            timeline_.NegotiateEnd(table_iter.first);
             ready_to_reduce.push_back(table_iter.first);
           }
         }

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -64,7 +64,7 @@ struct HorovodGlobalState {
 
   // Encapsulates the fusion buffers, handles resizing and auto-tuning of buffer
   // size.
-  FusionBufferManager fusion_buffer;
+  FusionBufferManager fusion_buffer; //TODO: probably vectorize
 
   // Time point when last cycle started.
   std::chrono::steady_clock::time_point last_cycle_start;
@@ -72,18 +72,18 @@ struct HorovodGlobalState {
   // Whether collective context has been completed on the background thread.
   std::atomic_bool initialization_done{false};
 
-  std::shared_ptr<Controller> controller;
+  std::vector<std::shared_ptr<Controller>> controller;
 
-  TensorQueue tensor_queue;
+  std::vector<TensorQueue> tensor_queue;
 
   // Pointer to shared buffer for allgather
-  void* shared_buffer = nullptr;
+  void* shared_buffer = nullptr; //TODO: vectorize
 
   // Current shared buffer size
-  int64_t shared_buffer_size = 0;
+  int64_t shared_buffer_size = 0; //TODO: vectorize
 
   // LRU cache of Responses
-  ResponseCache response_cache;
+  std::vector<ResponseCache> response_cache;
 
   // Number of responses that can be cached
   uint32_t cache_capacity = 1024;
@@ -95,7 +95,7 @@ struct HorovodGlobalState {
   int current_nccl_stream = 0;
 
   // Information on registered groups.
-  GroupTable group_table;
+  std::vector<GroupTable> group_table;
 
   // A LibType indicating what framework we are using to perform CPU operations.
   LibType cpu_operation;

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -153,6 +153,10 @@ void Request::set_prescale_factor(const double prescale_factor) { prescale_facto
 
 void Request::set_postscale_factor(const double postscale_factor) { postscale_factor_ = postscale_factor; };
 
+int32_t Request::communicator_id() const { return communicator_id_; }
+
+void Request::set_communicator_id(int32_t value) { communicator_id_ = value; }
+
 int32_t Request::group_id() const { return group_id_; }
 
 void Request::set_group_id(int32_t value) { group_id_ = value; }
@@ -394,6 +398,25 @@ double Response::postscale_factor() const { return postscale_factor_; };
 void Response::set_prescale_factor(const double prescale_factor) { prescale_factor_ = prescale_factor; };
 
 void Response::set_postscale_factor(const double postscale_factor) { postscale_factor_ = postscale_factor; };
+
+int32_t Response::communicator_id() const { return communicator_id_; };
+
+void Response::set_communicator_id(const int32_t value)
+{ communicator_id_ = value; };
+
+Response::Response(const Response& response){
+  set_response_type(response.response_type());
+  for (const auto& tensor_name_obj : response.tensor_names()) {
+    add_tensor_name(tensor_name_obj);
+  }
+  set_tensor_type(response.tensor_type());
+  set_error_message(response.error_message());
+  set_devices(response.devices());
+  set_tensor_sizes(response.tensor_sizes());
+  set_prescale_factor(response.prescale_factor());
+  set_postscale_factor(response.postscale_factor());
+  set_communicator_id(response.communicator_id());
+};
 
 void Response_ParseFromWire(Response& response,
                             const wire::Response* obj) {

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -98,6 +98,9 @@ public:
   void set_prescale_factor(const double prescale_factor);
 
   void set_postscale_factor(const double postscale_factor);
+  
+  int32_t communicator_id() const;
+  void set_communicator_id(int32_t value);
 
   static void ParseFromBytes(Request& request, const uint8_t* input);
 
@@ -117,6 +120,7 @@ private:
   std::vector<int64_t> tensor_shape_;
   double prescale_factor_ = 1.0;
   double postscale_factor_ = 1.0;
+  int32_t communicator_id_ = 0;
 };
 
 class RequestList {
@@ -154,6 +158,10 @@ public:
   enum ResponseType {
     ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL= 5, ERROR = 6
   };
+  
+  Response() {};
+  
+  Response(const Response& response);
 
   static const std::string& ResponseType_Name(ResponseType value);
 
@@ -206,6 +214,10 @@ public:
   void set_prescale_factor(const double prescale_factor);
 
   void set_postscale_factor(const double postscale_factor);
+  
+  int32_t communicator_id() const;
+  
+  void set_communicator_id(const int32_t value);
 
   static void ParseFromBytes(Response& response, const uint8_t* input);
 
@@ -221,6 +233,7 @@ private:
   std::vector<int64_t> tensor_sizes_;
   double prescale_factor_ = 1.0;
   double postscale_factor_ = 1.0;
+  int32_t communicator_id_ = 0;
 };
 
 class ResponseList {

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -765,13 +765,16 @@ void horovod_init(const int* ranks, int nranks) {
 
 #if HAVE_MPI
 void horovod_init_comm(MPI_Comm comm) {
-  //TODO: Allow to manually specify the communicators, for now, I'm going to create several comms
-  // Allocating as many mpi contexts as there are communicators, so let's imagine 3
-  mpi_context.resize(3);
   MPI_Comm_dup(comm, &mpi_context[0].mpi_comm);
-  MPI_Comm_dup(comm, &mpi_context[1].mpi_comm);
-  MPI_Comm_dup(comm, &mpi_context[2].mpi_comm);
   InitializeHorovodOnce(nullptr, 0);
+}
+
+void horovod_init_multi_comm(MPI_Comm *comm, int ncomms) {
+    // Resizing mpi_context to hold one context per communicator
+    mpi_context.resize(ncomms);
+    for(int i=0; i< ncomms; i++) 
+        MPI_Comm_dup(comm[i], &mpi_context[i].mpi_comm);
+    InitializeHorovodOnce(nullptr, 0);
 }
 #endif
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -757,7 +757,14 @@ Status CheckInitialized() {
 extern "C" {
 
 void horovod_init(const int* ranks, int nranks) {
-  InitializeHorovodOnce(ranks, nranks);
+  //TODO: Allow to manually specify the communicators, for now, I'm going to create several comms
+  // Allocating as many mpi contexts as there are communicators, so let's imagine 3
+  mpi_context.resize(3);
+  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[0].mpi_comm);
+  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[1].mpi_comm);
+  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[2].mpi_comm);
+  InitializeHorovodOnce(nullptr, 0);
+  // InitializeHorovodOnce(ranks, nranks);
 }
 
 #if HAVE_MPI

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -685,6 +685,9 @@ void InitializeHorovodOnce(const int* ranks, int nranks) {
     // Retrieve number of  contexts we are dealing with
     int64_t n_contexts = mpi_context.size();
     
+    // Resize gloo context to match mpi_context
+    gloo_context.resize(n_contexts);
+    
     // Resets OperationManager to appropriate size
     op_manager.resize(n_contexts);
     
@@ -757,14 +760,7 @@ Status CheckInitialized() {
 extern "C" {
 
 void horovod_init(const int* ranks, int nranks) {
-  //TODO: Allow to manually specify the communicators, for now, I'm going to create several comms
-  // Allocating as many mpi contexts as there are communicators, so let's imagine 3
-  mpi_context.resize(3);
-  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[0].mpi_comm);
-  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[1].mpi_comm);
-  MPI_Comm_dup(MPI_COMM_WORLD, &mpi_context[2].mpi_comm);
-  InitializeHorovodOnce(nullptr, 0);
-  // InitializeHorovodOnce(ranks, nranks);
+  InitializeHorovodOnce(ranks, nranks);
 }
 
 #if HAVE_MPI

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -823,7 +823,14 @@ bool horovod_stop_timeline() {
   return true;
 }
 
-int horovod_rank(int32_t communicator_id) {
+int horovod_rank() {
+  if (!horovod_global.initialization_done) {
+    return -1;
+  }
+  return horovod_global.controller[0]->GetRank();
+}
+
+int horovod_communicator_rank(int32_t communicator_id) {
   if (!horovod_global.initialization_done) {
     return -1;
   }
@@ -844,7 +851,14 @@ int horovod_cross_rank() {
   return horovod_global.controller[0]->GetCrossRank();
 }
 
-int horovod_size(int32_t communicator_id) {
+int horovod_size() {
+  if (!horovod_global.initialization_done) {
+    return -1;
+  }
+  return horovod_global.controller[0]->GetSize();
+}
+
+int horovod_communicator_size(int32_t communicator_id) {
   if (!horovod_global.initialization_done) {
     return -1;
   }

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -448,10 +448,10 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   state.mark_cycles_in_timeline = mark_cycles;
   
   for(int64_t i=0; i< mpi_context.size(); i++){
-    state.controller[0]->SetTimelineEnabled(should_enable_timeline);
+    state.controller[i]->SetTimelineEnabled(should_enable_timeline);
     
-    ParseStallInspectorFromEnv(state.controller[0]->GetStallInspector());
-    state.controller[0]->SetMarkCyclesInTimelinePending(mark_cycles);
+    ParseStallInspectorFromEnv(state.controller[i]->GetStallInspector());
+    state.controller[i]->SetMarkCyclesInTimelinePending(mark_cycles);
   }
   
   // Override Tensor Fusion threshold, if it's set.

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -371,7 +371,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
 #endif
   // Initialize each MPI context
   for(int64_t i=0; i < mpi_context.size(); i++)
-    mpi_context[0].Initialize(state.controller[0]->GetRanks(), mpi_ctx_manager);
+    mpi_context[i].Initialize(state.controller[i]->GetRanks(), mpi_ctx_manager);
 #endif
 
   

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -823,11 +823,11 @@ bool horovod_stop_timeline() {
   return true;
 }
 
-int horovod_rank() {
+int horovod_rank(int32_t communicator_id) {
   if (!horovod_global.initialization_done) {
     return -1;
   }
-  return horovod_global.controller[0]->GetRank();
+  return horovod_global.controller[communicator_id]->GetRank();
 }
 
 int horovod_local_rank() {
@@ -844,11 +844,11 @@ int horovod_cross_rank() {
   return horovod_global.controller[0]->GetCrossRank();
 }
 
-int horovod_size() {
+int horovod_size(int32_t communicator_id) {
   if (!horovod_global.initialization_done) {
     return -1;
   }
-  return horovod_global.controller[0]->GetSize();
+  return horovod_global.controller[communicator_id]->GetSize();
 }
 
 int horovod_local_size() {

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -47,6 +47,9 @@ void horovod_init(const int *ranks, int nranks);
 #if HAVE_MPI
 // C interface to initialize Horovod with the given MPI communicator.
 void horovod_init_comm(MPI_Comm comm);
+
+// C interface to initialize Horovod with an array of existing MPI communicators.
+void horovod_init_multi_comm(MPI_Comm *comm, int ncomms);
 #endif
 
 // C interface to shut down Horovod.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -57,7 +57,8 @@ void horovod_shutdown();
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.
-int horovod_rank(int32_t communicator_id=0);
+int horovod_rank();
+int horovod_rank_communicator(int32_t communicator_id=0);
 
 // C interface to get index of current Horovod process in the node it is on.
 // Returns -1 if Horovod is not initialized.
@@ -65,7 +66,8 @@ int horovod_local_rank();
 
 // C interface to return number of Horovod processes.
 // Returns -1 if Horovod is not initialized.
-int horovod_size(int32_t communicator_id=0);
+int horovod_size();
+int horovod_size_communicator(int32_t communicator_id=0);
 
 // C interface to return number of Horovod processes in the node it is on.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -57,7 +57,7 @@ void horovod_shutdown();
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.
-int horovod_rank();
+int horovod_rank(int32_t communicator_id=0);
 
 // C interface to get index of current Horovod process in the node it is on.
 // Returns -1 if Horovod is not initialized.
@@ -65,7 +65,7 @@ int horovod_local_rank();
 
 // C interface to return number of Horovod processes.
 // Returns -1 if Horovod is not initialized.
-int horovod_size();
+int horovod_size(int32_t communicator_id=0);
 
 // C interface to return number of Horovod processes in the node it is on.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -119,7 +119,8 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
                               StatusCallback callback,
                               ReduceOp reduce_op = ReduceOp::SUM,
                               double prescale_factor = 1.0,
-                              double postscale_factor = 1.0);
+                              double postscale_factor = 1.0,
+                              int32_t communicator_id= 0);
 
 Status EnqueueTensorAllreduces(std::vector<std::shared_ptr<OpContext>>& contexts,
                                std::vector<std::shared_ptr<Tensor>>& tensors,
@@ -130,32 +131,37 @@ Status EnqueueTensorAllreduces(std::vector<std::shared_ptr<OpContext>>& contexts
                                std::vector<StatusCallback>& callbacks,
                                ReduceOp reduce_op = ReduceOp::SUM,
                                double prescale_factor = 1.0,
-                               double postscale_factor = 1.0);
+                               double postscale_factor = 1.0,
+                               int32_t communicator_id = 0);
 
 Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string& name, int device,
-                              StatusCallback callback);
+                              StatusCallback callback,
+                              int32_t communicator_id = 0);
 
 Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,
                               std::shared_ptr<Tensor> output, int root_rank,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string& name, int device,
-                              StatusCallback callback);
+                              StatusCallback callback,
+                              int32_t communicator_id = 0);
 
 Status EnqueueTensorAlltoall(std::shared_ptr<OpContext> context,
                              std::shared_ptr<Tensor> tensor,
                              std::shared_ptr<Tensor> splits,
                              std::shared_ptr<ReadyEvent> ready_event,
                              const std::string& name, int device,
-                             StatusCallback callback);
+                             StatusCallback callback,
+                             int32_t communicator_id = 0);
 
 Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    std::shared_ptr<ReadyEvent> ready_event,
                    const std::string& name, int device,
-                   StatusCallback callback);
+                   StatusCallback callback,
+                   int32_t communicator_id = 0);
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/adasum/adasum.h
+++ b/horovod/common/ops/adasum/adasum.h
@@ -199,7 +199,7 @@ private:
                       Communicator_type* reduction_comms,
                       HorovodGlobalState* global_state) {
     int per_element_size =
-        global_state->controller->GetTypeSize(horovod_datatype);
+        global_state->controller[0]->GetTypeSize(horovod_datatype);
     int rank = GetLocalRankWithComm(communicator);
     int size = GetSizeWithComm(communicator);
 
@@ -344,7 +344,7 @@ private:
                                    HorovodGlobalState* global_state) {
     static double sqrt_double_min = std::sqrt(DBL_MIN);
     int per_element_size =
-        global_state->controller->GetTypeSize(horovod_datatype);
+        global_state->controller[0]->GetTypeSize(horovod_datatype);
     int bytesSoFar = 0;
     for (size_t i = 0; i < tensor_counts.size(); i++) {
       double dotProduct = 0.;

--- a/horovod/common/ops/adasum/adasum_mpi.cc
+++ b/horovod/common/ops/adasum/adasum_mpi.cc
@@ -101,7 +101,7 @@ void AdasumMPI::PointToPointSendRecv(
     DataType horovod_datatype, int dst_src_rank, int tag, MPI_Comm communicator,
     HorovodGlobalState* global_state) {
   int status;
-  int element_size = global_state->controller->GetTypeSize(horovod_datatype);
+  int element_size = global_state->controller[0]->GetTypeSize(horovod_datatype);
   int input_count = input_buffer_length / element_size;
   int output_count = output_buffer_length / element_size;
   int chunk_count =

--- a/horovod/common/ops/adasum_gpu_operations.cc
+++ b/horovod/common/ops/adasum_gpu_operations.cc
@@ -66,7 +66,7 @@ AdasumGpuAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     nccl_device_map.push_back(response.devices()[rank]);
   }
   gpu_op_context_.InitGPU(entries);
-  nccl_op_context_.InitNCCLComm(entries, nccl_device_map);
+  nccl_op_context_.InitNCCLComm(entries, nccl_device_map, 0);
   gpu_op_context_.InitGPUQueue(entries, response);
   const void* fused_input_data;
   void* buffer_data;

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -266,7 +266,7 @@ Status JoinOp::Execute(std::vector<TensorTableEntry>& entries,
                        const Response& response) {
   assert(entries.size() == 0);
   if (global_state_->joined) {
-    global_state_->tensor_queue[0].RemoveJoinTensor();
+    global_state_->tensor_queue[response.communicator_id()].RemoveJoinTensor();
     global_state_->joined = false;
   }
   return Status::OK();

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -143,24 +143,27 @@ protected:
                                 int64_t**& entry_component_sizes,
                                 int*& recvcounts);
 
-  virtual void SetDisplacements(const int* recvcounts, int*& displcmnts);
+  virtual void SetDisplacements(const int* recvcounts, int*& displcmnts, const int32_t communicator_id);
 
   virtual void
   SetEntryComponentOffsets(const std::vector<TensorTableEntry>& entries,
                            const int64_t* const* entry_component_sizes,
                            const int* recvcounts,
-                           int64_t**& entry_component_offsets);
+                           int64_t**& entry_component_offsets, 
+                           const int32_t communicator_id);
 
   virtual void
   MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                        const int* displcmnts, int element_size,
-                       void*& buffer_data);
+                       void*& buffer_data, 
+                       const int32_t communicator_id);
 
   virtual void
   MemcpyOutFusionBuffer(const int64_t* const* entry_component_offsets,
                         const int64_t* const* entry_component_sizes,
                         const void* buffer_data, int element_size,
-                        std::vector<TensorTableEntry>& entries);
+                        std::vector<TensorTableEntry>& entries, 
+                        const int32_t communicator_id);
 
   virtual void
   MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -209,12 +209,12 @@ protected:
                                 std::vector<T>& rdispls,
                                 std::vector<T>& sendcounts,
                                 std::vector<T>& recvcounts) {
-    auto world_size = global_state_->controller->GetSize();
+    auto world_size = global_state_->controller[0]->GetSize();
 
     const auto& splits = e.splits;
     std::vector<int32_t> recvsplits;
     // Perform alltoall of splits to get expected receive splits
-    global_state_->controller->AlltoallGetRecvSplits(splits, recvsplits);
+    global_state_->controller[0]->AlltoallGetRecvSplits(splits, recvsplits);
 
     // Every tensor participating in Alltoall operation may have different
     // first dimension size, but the rest of dimensions are same for all

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -211,13 +211,14 @@ protected:
                                 std::vector<T>& sdispls,
                                 std::vector<T>& rdispls,
                                 std::vector<T>& sendcounts,
-                                std::vector<T>& recvcounts) {
-    auto world_size = global_state_->controller[0]->GetSize();
+                                std::vector<T>& recvcounts,
+                                const int32_t communicator_id) {
+    auto world_size = global_state_->controller[communicator_id]->GetSize();
 
     const auto& splits = e.splits;
     std::vector<int32_t> recvsplits;
     // Perform alltoall of splits to get expected receive splits
-    global_state_->controller[0]->AlltoallGetRecvSplits(splits, recvsplits);
+    global_state_->controller[communicator_id]->AlltoallGetRecvSplits(splits, recvsplits);
 
     // Every tensor participating in Alltoall operation may have different
     // first dimension size, but the rest of dimensions are same for all

--- a/horovod/common/ops/gloo_operations.cc
+++ b/horovod/common/ops/gloo_operations.cc
@@ -192,7 +192,7 @@ Status GlooAllgather::Execute(std::vector<TensorTableEntry>& entries,
   // allgatherv
   auto** entry_component_offsets = new int64_t*[entries.size()];
 
-  int global_size = global_state_->controller->GetSize();
+  int global_size = global_state_->controller[0]->GetSize();
   auto* recvcounts = new int[global_size]();
   auto* displcmnts = new int[global_size]();
 
@@ -285,7 +285,7 @@ Status GlooBroadcast::Execute(std::vector<TensorTableEntry>& entries,
   // for gloo broadcast, only output needs to be set if inplace
 
   void* data_ptr;
-  if (global_state_->controller->GetRank() == e.root_rank) {
+  if (global_state_->controller[0]->GetRank() == e.root_rank) {
     data_ptr = (void*)e.tensor->data();
   } else {
     data_ptr = (void*)e.output->data();

--- a/horovod/common/ops/gloo_operations.cc
+++ b/horovod/common/ops/gloo_operations.cc
@@ -319,7 +319,7 @@ Status GlooAlltoall::Execute(std::vector<TensorTableEntry>& entries, const Respo
 
   std::vector<int64_t> sdispls, rdispls;
   std::vector<int64_t> sendcounts, recvcounts;
-  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts);
+  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts, response.communicator_id());
   if (!status.ok()) {
     return status;
   }

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -108,7 +108,7 @@ Status MPI_GPUAllgather::Execute(std::vector<TensorTableEntry>& entries, const R
   // allgatherv
   auto** entry_component_offsets = new int64_t* [entries.size()];
 
-  int global_size = global_state_->controller->GetSize();
+  int global_size = global_state_->controller[0]->GetSize();
   auto* recvcounts = new int[global_size]();
   auto* displcmnts = new int[global_size]();
 

--- a/horovod/common/ops/mpi_operations.cc
+++ b/horovod/common/ops/mpi_operations.cc
@@ -398,7 +398,7 @@ Status MPIAlltoall::Execute(std::vector<TensorTableEntry>& entries, const Respon
 
   std::vector<int32_t> sdispls, rdispls;
   std::vector<int32_t> sendcounts, recvcounts;
-  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts);
+  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts, response.communicator_id());
   if (!status.ok()) {
     return status;
   }

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -59,7 +59,7 @@ public:
         communicator_type_(communicator_type){};
 
   void InitNCCLComm(const std::vector<TensorTableEntry>& entries,
-                    const std::vector<int32_t>& nccl_device_map);
+                    const std::vector<int32_t>& nccl_device_map, const int32_t communicator_id);
 
   void AsyncErrorCheck();
 
@@ -68,7 +68,7 @@ public:
 
 private:
   void PopulateNCCLCommStrategy(int& nccl_rank, int& nccl_size,
-                                Communicator& nccl_id_bcast_comm);
+                                Communicator& nccl_id_bcast_comm, const int32_t communicator_id);
 
   NCCLContext* nccl_context_;
   HorovodGlobalState* global_state_;

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -53,7 +53,7 @@ if tf.__version__.startswith('2.2.'):
 
 def allreduce(tensor, average=None, device_dense='', device_sparse='',
               compression=Compression.none, op=None,
-              prescale_factor=1.0, postscale_factor=1.0,
+              prescale_factor=1.0, postscale_factor=1.0, communicator_id=0,
               name=None):
     """Perform an allreduce on a tf.Tensor or tf.IndexedSlices.
 
@@ -81,6 +81,7 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
             Defaults to Average if None is given.
         prescale_factor: Multiplicative factor to scale tensor before allreduce.
         postscale_factor: Multiplicative factor to scale tensor after allreduce.
+        communicator_id: Id of the communicator to use for this operation
         name: A name of the allreduce operation
 
     Returns:
@@ -120,6 +121,7 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
             summed_tensor_compressed = _allreduce(tensor_compressed, op=op,
                                                   prescale_factor=prescale_factor,
                                                   postscale_factor=postscale_factor,
+                                                  communicator_id=communicator_id,
                                                   name=name)
             summed_tensor = compression.decompress(summed_tensor_compressed, ctx)
             if op == Adasum:
@@ -155,7 +157,7 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
 
 def grouped_allreduce(tensors, average=None, device_dense='', device_sparse='',
                       compression=Compression.none, op=None,
-                      prescale_factor=1.0, postscale_factor=1.0):
+                      prescale_factor=1.0, postscale_factor=1.0, communicator_id=0):
     if not tensors:
         return tensors
 
@@ -191,7 +193,8 @@ def grouped_allreduce(tensors, average=None, device_dense='', device_sparse='',
             tensors_compressed, ctxs = zip(*[compression.compress(tensor) for tensor in tensors])
             summed_tensors_compressed = _grouped_allreduce(tensors_compressed, op=op,
                                                            prescale_factor=prescale_factor,
-                                                           postscale_factor=postscale_factor)
+                                                           postscale_factor=postscale_factor,
+                                                           communicator_id=communicator_id)
             summed_tensors = [compression.decompress(t, ctx) for t, ctx in zip(summed_tensors_compressed, ctxs)]
             if op == Adasum:
                 if 'CPU' not in tensor.device and gpu_available('tensorflow'):


### PR DESCRIPTION
I'm opening this draft PR to facilitate reviewing/comments on our efforts to integrate support for multiple communicators in Horovod. This is heavily inspired from your code @kimchitsigai  and @mypey (in branches `comms-idris-MP` and `comms-idris-JS`), I've made a few clean ups and proposed a few simplifications, trying to follow the recommendations in https://github.com/horovod/horovod/issues/2139 .

Here is a summary of the approach:
- We create an array of MPI contexts, each MPI context will be based on one user-provided communicator (just like in the current `horovod_init_comm(MPI_Comm comm)`)
- For each context/communicator, we create a specific controller, tensor queue, and operations manager. When these are created, we give them the corresponding mpi_context. 
- In the horovod loop, we construct the message list, and run communication operations, for each context/communicator one by one. 

Most of the code modifications is to turn references to `global_state.controller` to `global_state.controller[communicator_id]` where the `communicator_id` is usually accessible through the message or request in internal functions. I've also assumed that we'll try to use `global_state.controller[0]` for COMM_WORLD, but nothing enforces it so far.

Note that the implementation is not yet complete, for now I haven't bothered with the adasum operations, and they are ignoring the multiple potential communicators, only using the one with index 0. Also, only a few tensorflow python operations support specifying which communicator to use for now.

## Open questions

Mostly about whether to duplicate some global state variables. Remember that each controller produces a response list that is then processed BEFORE running the next controller. So, if we assume that one horovod loop leave these variables in a clean state, it should be ok not to duplicate them:
- [ ] : Do we need to be careful about the `global_state.fusion_buffer` or can it be shared between different controllers? 
- [ ] : Do we need to be careful about the `global_state.shared_buffer` or can it be shared between different controllers?
- [ ] : Do we need to be careful about the  `global_state.joined_size`  or can it be shared between different controllers?
- [ ] : And check all other shared global variables.

Next questions are about how optimized this approach is:
- [ ] : Should we compute all response lists first, then  merge them, and run the Execute once? Or is the current approach of processing jointly each controller's response list and its execution ok?

## Example

Here is how one would use this:
```python
from mpi4py import MPI

# This will be our baseline world communicator
comm = MPI.COMM_WORLD
# Split COMM_WORLD into subcommunicators
subcomm = MPI.COMM_WORLD.Split(color=MPI.COMM_WORLD.rank % 2,
                               key=MPI.COMM_WORLD.rank)

# And here is our array of communicators
comms = [comm, subcomm]

import tensorflow as tf
import horovod.tensorflow as hvd

# Initialize Horovod
hvd.init(comm=comms)

# Let's try to operate on some tensors
a = (r+1)*tf.ones(10)

print("AlltoAll on WORLD", hvd.alltoall(a, communicator_id=0))

print("AlltoAll on sub communicator", hvd.alltoall(a, communicator_id=1))
```

To run this for instance on my little machine with 2 GPUs:
```bash
$ horovodrun -np 2  --timeline-filename my_timeline.json --timeline-mark-cycles python test_hvd.py
```
Note this outputs a timeline, where you can see if it goes through the NCCL ops or not  (more info [here](https://horovod.readthedocs.io/en/stable/timeline_include.html) ).

To compile with NCCL and MPI support I'm using the following command line:
```bash
$ HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_MPI=1 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITHOUT_PYTORCH=1 python setup.py develop --user
```